### PR TITLE
Fix issue in xacro syntax and adds compatibility with ROS noetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Install build dependency
+
+sudo apt install ros-noetic-move-base-msgs
+
+
 # Differential-drive mobile robot using ROS
 
 To see the robot in rviz, read the _README_ file inside the `my_robot_description` package.

--- a/my_robot_description/urdf/macros.xacro
+++ b/my_robot_description/urdf/macros.xacro
@@ -71,7 +71,7 @@
         <origin xyz="0 0 0" 
         		rpy="${-tY*PI/2} 0 0" />
         <mass value="${wheelMass}"/>
-        <cylinder_inertia 
+        <xacro:cylinder_inertia 
           m="${wheelMass}" 
           r="${wheelRadius}" 
           h="${wheelWidth}"/>

--- a/my_robot_description/urdf/my_robot.xacro
+++ b/my_robot_description/urdf/my_robot.xacro
@@ -56,7 +56,7 @@
 			<origin xyz="0 0 ${wheelRadius}" 
 					rpy="0 0 0"/> 
 			<mass value="${chassisMass}"/> 
-			<box_inertia 
+			<xacro:box_inertia 
 				m="${chassisMass}" 
 				x="${chassisLength}" 
 				y="${chassisWidth}" 
@@ -95,7 +95,7 @@
 			<origin xyz="${casterOffsetX} 0 ${2*casterRadius}" 
 					rpy="0 0 0"/>
 			<mass value="${casterMass}"/>
-			<sphere_inertia 
+			<xacro:sphere_inertia 
 				m="${casterMass}" 
 				r="${casterRadius}"/>
 		</inertial>
@@ -104,8 +104,8 @@
 
 
 
-	<wheel lr="left" tY="-1"/>
-	<wheel lr="right" tY="1"/>
+	<xacro:wheel lr="left" tY="-1"/>
+	<xacro:wheel lr="right" tY="1"/>
 
 
 	<!-- Sensor models -->

--- a/my_robot_description/urdf/sensors.xacro
+++ b/my_robot_description/urdf/sensors.xacro
@@ -51,7 +51,7 @@
       <mass value="${cameraMass}" />
       <origin xyz="0 0 0" 
               rpy="0 0 0"/>
-      <box_inertia m="${cameraMass}" 
+      <xacro:box_inertia m="${cameraMass}" 
                    x="${cameraLength}" 
                    y="${cameraWidth}" 
                    z="${cameraHeight}" />
@@ -102,7 +102,7 @@
       <mass value="${hokuyoMass}" />
       <origin xyz="0 0 0" 
               rpy="0 0 0"/>
-      <box_inertia 
+      <xacro:box_inertia 
         m="${hokuyoMass}" 
         x="${hokuyoLength}" 
         y="${hokuyoWidth}" 

--- a/my_robot_gazebo/README.md
+++ b/my_robot_gazebo/README.md
@@ -14,8 +14,8 @@ $ source devel/setup.bash
 Install dependencies: 
 
 ```bash
-$ sudo apt-get install ros-kinetic-ros-control
-$ sudo apt-get install ros-kinetic-controller-manager
+$ sudo apt-get install ros-noetic-ros-control
+$ sudo apt-get install ros-noetic-controller-manager
 ```
 
 ### Test

--- a/my_robot_gazebo/README.md
+++ b/my_robot_gazebo/README.md
@@ -16,6 +16,7 @@ Install dependencies:
 ```bash
 $ sudo apt-get install ros-noetic-ros-control
 $ sudo apt-get install ros-noetic-controller-manager
+$ sudo apt-get install ros-noetic-effort-controllers
 ```
 
 ### Test
@@ -32,7 +33,7 @@ $ roslaunch my_robot_gazebo my_robot_world.launch
 
 Move with the keyboard:
 ```
-$ rosrun turtlebot_teleop turtlebot_teleop_key /turtlebot_teleop/cmd_vel:=/my_robot/cmd_vel
+$ rosrun turtlebot3_teleop turtlebot3_teleop_key /cmd_vel:=/my_robot/cmd_vel
 ```
 
 ![Gazebo simulation](../resources/gazebo.jpg)

--- a/my_robot_gazebo/launch/my_robot_world.launch
+++ b/my_robot_gazebo/launch/my_robot_world.launch
@@ -20,7 +20,7 @@
 		 default="false"/>
 
 	<arg name="world"
-		 default="$(find turtlebot_gazebo)/worlds/corridor.world"/>
+		 default="$(find turtlebot3_gazebo)/worlds/turtlebot3_world.world"/>
 
 	<arg name="model" 
   	   	 default="$(find my_robot_description)/urdf/my_robot.xacro"/>


### PR DESCRIPTION
When attempted to run the simulations I ran into issues with xacro macros syntax. I also noticed that the simulations had dependency with the turtlebot packages with are now outdated so these were updates to use turtlebot3.

Possibly Fixes issue #5 